### PR TITLE
1、修复例子引用丢失的问题 2、修复OpenScript时会显示包含类名的其他脚本 3、修复节点名称、浮动提示等字段为null不显示的问题

### DIFF
--- a/Core/Util/GraphProcessorUtil.cs
+++ b/Core/Util/GraphProcessorUtil.cs
@@ -28,7 +28,7 @@ namespace Atom.GraphProcessor
         public T Value;
     }
 
-    public struct NodeStaticInfo
+    public class NodeStaticInfo
     {
         public Type NodeType;
         public bool Hidden;

--- a/Examples/MathExample/MathExample.unity
+++ b/Examples/MathExample/MathExample.unity
@@ -38,12 +38,11 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,13 +97,13 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +116,9 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -161,9 +162,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -197,12 +206,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 955132296}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1740746575
 GameObject:
@@ -214,6 +224,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1740746577}
   - component: {fileID: 1740746576}
+  - component: {fileID: 1740746578}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -280,6 +291,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1740746577
@@ -289,13 +301,37 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1740746575}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1740746578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1740746575}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1 &2128358073
 GameObject:
   m_ObjectHideFlags: 0
@@ -325,7 +361,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1164b4925701bb4d99f653f65933da7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  graphAsset: {fileID: 11400000, guid: 50b186c59c463614fa591c97cc87c5df, type: 2}
+  graphAsset: {fileID: 11400000, guid: a2a0169845db09b48a1824f3cfa2750f, type: 2}
 --- !u!4 &2128358075
 Transform:
   m_ObjectHideFlags: 0
@@ -333,10 +369,18 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2128358073}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 8.510222, y: -10.254931, z: 22.299038}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 955132299}
+  - {fileID: 1740746577}
+  - {fileID: 2128358075}

--- a/UnityEX/Editor/Views/BaseNodeView.cs
+++ b/UnityEX/Editor/Views/BaseNodeView.cs
@@ -37,11 +37,29 @@ namespace Atom.GraphProcessor.Editors
         {
             foreach (var script in EditorUtilityExtension.FindAllScriptFromType(ViewModel.GetType()))
             {
+                if (script.GetClass() == null)
+                {
+                    continue;
+                }
+                if (!script.GetClass().IsSubclassOf(typeof(BaseNodeProcessor)))
+                {
+                    continue;
+                }
+                
                 evt.menu.AppendAction($"Open Script/" + script.name, _ => { AssetDatabase.OpenAsset(script); });
             }
 
             foreach (var script in EditorUtilityExtension.FindAllScriptFromType(ViewModel.Model.GetType()))
             {
+                if (script.GetClass() == null)
+                {
+                    continue;
+                }
+                if (!script.GetClass().IsSubclassOf(typeof(BaseNode)))
+                {
+                    continue;
+                }
+                
                 evt.menu.AppendAction($"Open Script/" + script.name, _ => { AssetDatabase.OpenAsset(script); });
             }
 


### PR DESCRIPTION
1、[示例场景MathExample.unity的asset引用丢失](https://github.com/haloman9527/3.0_GraphProcessor/commit/86eceb18460f75f8216ea19a48668af2c3422036)
2、[OpenScript构造菜单时时增加基类判断，修复OpenScript时会显示包含类名的其他脚本](https://github.com/haloman9527/3.0_GraphProcessor/commit/e317d752ff12e0e076c11d37a51f1b414e1cbbb0)
3、[NodeStaticInfo改为class，修复节点名称、浮动提示等字段为null不显示的问题](https://github.com/haloman9527/3.0_GraphProcessor/commit/11e5fabcb4808956c2adc90a270f466767b91af6)
由于struct值拷贝的原因，会导致Tilte、ToolTips等字段为null，当然不改class，只改原代码的赋值和添加字典的顺序也可以解决